### PR TITLE
Updating Regex to Allow Spaces, Disallow Tabs

### DIFF
--- a/conf/modules.config
+++ b/conf/modules.config
@@ -35,6 +35,6 @@ process {
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
-        ext.args = "--age_header ${params.age_header}"
+        ext.args = "--age_header '${params.age_header}'"
     }
 }

--- a/conf/modules.config
+++ b/conf/modules.config
@@ -35,6 +35,6 @@ process {
             mode: params.publish_dir_mode,
             saveAs: { filename -> filename.equals('versions.yml') ? null : filename }
         ]
-        ext.args = "--age_header '${params.age_header}'"
+        ext.args = "--age_header \"${params.age_header}\""
     }
 }

--- a/nextflow_schema.json
+++ b/nextflow_schema.json
@@ -54,7 +54,7 @@
                     "type": "string",
                     "default": "age",
                     "description": "The column header name for the calculated age in the calculate age metadata transformation.",
-                    "pattern": "^[^\\s\\\",]*$"
+                    "pattern": "^[^\\t\\\",]*$"
                 }
             }
         },
@@ -68,49 +68,49 @@
                     "type": "string",
                     "default": "metadata_1",
                     "description": "The column header name for the 1st metadata column.",
-                    "pattern": "^[^\\s\\\",]*$"
+                    "pattern": "^[^\\t\\\",]*$"
                 },
                 "metadata_2_header": {
                     "type": "string",
                     "default": "metadata_2",
                     "description": "The column header name for the 2nd metadata column.",
-                    "pattern": "^[^\\s\\\",]*$"
+                    "pattern": "^[^\\t\\\",]*$"
                 },
                 "metadata_3_header": {
                     "type": "string",
                     "default": "metadata_3",
                     "description": "The column header name for the 3rd metadata column.",
-                    "pattern": "^[^\\s\\\",]*$"
+                    "pattern": "^[^\\t\\\",]*$"
                 },
                 "metadata_4_header": {
                     "type": "string",
                     "default": "metadata_4",
                     "description": "The column header name for the 4th metadata column.",
-                    "pattern": "^[^\\s\\\",]*$"
+                    "pattern": "^[^\\t\\\",]*$"
                 },
                 "metadata_5_header": {
                     "type": "string",
                     "default": "metadata_5",
                     "description": "The column header name for the 5th metadata column.",
-                    "pattern": "^[^\\s\\\",]*$"
+                    "pattern": "^[^\\t\\\",]*$"
                 },
                 "metadata_6_header": {
                     "type": "string",
                     "default": "metadata_6",
                     "description": "The column header name for the 6th metadata column.",
-                    "pattern": "^[^\\s\\\",]*$"
+                    "pattern": "^[^\\t\\\",]*$"
                 },
                 "metadata_7_header": {
                     "type": "string",
                     "default": "metadata_7",
                     "description": "The column header name for the 7th metadata column.",
-                    "pattern": "^[^\\s\\\",]*$"
+                    "pattern": "^[^\\t\\\",]*$"
                 },
                 "metadata_8_header": {
                     "type": "string",
                     "default": "metadata_8",
                     "description": "The column header name for the 8th metadata column.",
-                    "pattern": "^[^\\s\\\",]*$"
+                    "pattern": "^[^\\t\\\",]*$"
                 }
             }
         },

--- a/tests/pipelines/age.nf.test
+++ b/tests/pipelines/age.nf.test
@@ -316,4 +316,92 @@ nextflow_pipeline {
             assert iridanext_metadata.sample3.age_at_collection.size() == 0
         }
     }
+
+    test("Spaces in headers") {
+        tag "pipeline_age"
+        tag "pipeline_age_spaces"
+
+        when {
+            params {
+                input = "$baseDir/tests/data/samplesheets/age/basic.csv"
+                outdir = "results"
+
+                transformation = "age"
+                metadata_1_header "date of birth"
+                metadata_2_header "collection date"
+                age_header "age at collection"
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert path("$launchDir/results").exists()
+
+            // Check Transformation (Machine-Readable)
+            def transformation = path("$launchDir/results/transformation/transformation.csv")
+            assert transformation.exists()
+
+            assert transformation.text.contains("sample,age at collection")
+            assert transformation.text.contains("sample1,0.0000")
+            assert transformation.text.contains("sample2,0.0027")
+            assert transformation.text.contains("sample3,0.2493")
+            assert transformation.text.contains("sample4,1.0000")
+            assert transformation.text.contains("sample5,1.2493")
+            assert transformation.text.contains("sample6,2")
+            assert transformation.text.contains("sample7,2")
+            assert transformation.text.contains("sample8,24")
+            assert transformation.text.contains("sample9,49")
+
+            // Check Results (Human-Readable)
+            def results = path("$launchDir/results/transformation/results.csv")
+            assert results.exists()
+
+            assert results.text.contains("sample,sample_name,date of birth,collection date,age at collection,age at collection_valid,age at collection_error")
+            assert results.text.contains("sample1,ABC,2000-01-01,2000-01-01,0.0000,True,")
+            assert results.text.contains("sample2,DEF,2000-01-01,2000-01-02,0.0027,True,")
+            assert results.text.contains("sample3,GHI,2000-01-01,2000-04-01,0.2493,True,")
+            assert results.text.contains("sample4,JKL,2000-01-01,2000-12-31,1.0000,True,")
+            assert results.text.contains("sample5,MNO,2000-01-01,2001-04-01,1.2493,True,")
+            assert results.text.contains("sample6,PQR,2000-01-01,2001-12-31,2,True,")
+            assert results.text.contains("sample7,STU,2000-01-01,2002-01-01,2,True,")
+            assert results.text.contains("sample8,VWX,2000-02-29,2024-02-29,24,True,")
+            assert results.text.contains("sample9,YZ,1950-12-31,2000-05-05,49,True,")
+
+            // Check IRIDA Next JSON Output
+            def iridanext_json = path("$launchDir/results/iridanext.output.json").json
+            def iridanext_global = iridanext_json.files.global
+            def iridanext_metadata = iridanext_json.metadata.samples
+
+            assert iridanext_global.findAll { it.path == "transformation/results.csv" }.size() == 1
+
+            assert iridanext_metadata.size() == 9
+
+            assert iridanext_metadata.containsKey("sample1")
+            assert iridanext_metadata.sample1."age at collection" == "0.0000"
+
+            assert iridanext_metadata.containsKey("sample2")
+            assert iridanext_metadata.sample2."age at collection" == "0.0027"
+
+            assert iridanext_metadata.containsKey("sample3")
+            assert iridanext_metadata.sample3."age at collection" == "0.2493"
+
+            assert iridanext_metadata.containsKey("sample4")
+            assert iridanext_metadata.sample4."age at collection" == "1.0000"
+
+            assert iridanext_metadata.containsKey("sample5")
+            assert iridanext_metadata.sample5."age at collection" == "1.2493"
+
+            assert iridanext_metadata.containsKey("sample6")
+            assert iridanext_metadata.sample6."age at collection" == "2"
+
+            assert iridanext_metadata.containsKey("sample7")
+            assert iridanext_metadata.sample7."age at collection" == "2"
+
+            assert iridanext_metadata.containsKey("sample8")
+            assert iridanext_metadata.sample8."age at collection" == "24"
+
+            assert iridanext_metadata.containsKey("sample9")
+            assert iridanext_metadata.sample9."age at collection" == "49"
+        }
+    }
 }

--- a/tests/pipelines/lock.nf.test
+++ b/tests/pipelines/lock.nf.test
@@ -394,4 +394,88 @@ nextflow_pipeline {
             assert iridanext_metadata.sample3.me_t_a_8 == "3.8"
         }
     }
+
+    test("Spaces in headers") {
+        tag "pipeline_lock"
+        tag "pipeline_lock_spaces"
+
+        when {
+            params {
+                input = "$baseDir/tests/data/samplesheets/lock/basic.csv"
+                outdir = "results"
+
+                transformation = "lock"
+                metadata_1_header "meta 1"
+                metadata_2_header "meta 2"
+                metadata_3_header "meta 3"
+                metadata_4_header "meta 4"
+                metadata_5_header "meta 5"
+                metadata_6_header "meta 6"
+                metadata_7_header "meta 7"
+                metadata_8_header "meta 8"
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert path("$launchDir/results").exists()
+
+            // Check Transformation (Machine-Readable)
+            def transformation = path("$launchDir/results/transformation/transformation.csv")
+            assert transformation.exists()
+
+            assert transformation.text.contains("sample,meta 1,meta 2,meta 3,meta 4,meta 5,meta 6,meta 7,meta 8")
+            assert transformation.text.contains("sample1,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8")
+            assert transformation.text.contains("sample2,2.1,2.2,2.3,2.4,2.5,2.6,2.7,2.8")
+            assert transformation.text.contains("sample3,3.1,3.2,3.3,3.4,3.5,3.6,3.7,3.8")
+
+            // Check Results (Human-Readable)
+            def results = path("$launchDir/results/transformation/results.csv")
+            assert results.exists()
+
+            assert results.text.contains("sample,sample_name,meta 1,meta 2,meta 3,meta 4,meta 5,meta 6,meta 7,meta 8")
+            assert results.text.contains("sample1,ABC,1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8")
+            assert results.text.contains("sample2,DEF,2.1,2.2,2.3,2.4,2.5,2.6,2.7,2.8")
+            assert results.text.contains("sample3,GHI,3.1,3.2,3.3,3.4,3.5,3.6,3.7,3.8")
+
+            // Check IRIDA Next JSON Output
+            def iridanext_json = path("$launchDir/results/iridanext.output.json").json
+            def iridanext_global = iridanext_json.files.global
+            def iridanext_metadata = iridanext_json.metadata.samples
+
+            assert iridanext_global.findAll { it.path == "transformation/results.csv" }.size() == 1
+
+            assert iridanext_metadata.size() == 3
+
+            assert iridanext_metadata.containsKey("sample1")
+            assert iridanext_metadata.sample1."meta 1" == "1.1"
+            assert iridanext_metadata.sample1."meta 2" == "1.2"
+            assert iridanext_metadata.sample1."meta 3" == "1.3"
+            assert iridanext_metadata.sample1."meta 4" == "1.4"
+            assert iridanext_metadata.sample1."meta 5" == "1.5"
+            assert iridanext_metadata.sample1."meta 6" == "1.6"
+            assert iridanext_metadata.sample1."meta 7" == "1.7"
+            assert iridanext_metadata.sample1."meta 8" == "1.8"
+
+            assert iridanext_metadata.containsKey("sample2")
+            assert iridanext_metadata.sample2."meta 1" == "2.1"
+            assert iridanext_metadata.sample2."meta 2" == "2.2"
+            assert iridanext_metadata.sample2."meta 3" == "2.3"
+            assert iridanext_metadata.sample2."meta 4" == "2.4"
+            assert iridanext_metadata.sample2."meta 5" == "2.5"
+            assert iridanext_metadata.sample2."meta 6" == "2.6"
+            assert iridanext_metadata.sample2."meta 7" == "2.7"
+            assert iridanext_metadata.sample2."meta 8" == "2.8"
+
+            assert iridanext_metadata.containsKey("sample3")
+            assert iridanext_metadata.sample3."meta 1" == "3.1"
+            assert iridanext_metadata.sample3."meta 2" == "3.2"
+            assert iridanext_metadata.sample3."meta 3" == "3.3"
+            assert iridanext_metadata.sample3."meta 4" == "3.4"
+            assert iridanext_metadata.sample3."meta 5" == "3.5"
+            assert iridanext_metadata.sample3."meta 6" == "3.6"
+            assert iridanext_metadata.sample3."meta 7" == "3.7"
+            assert iridanext_metadata.sample3."meta 8" == "3.8"
+        }
+    }
 }


### PR DESCRIPTION
Continuing to disallow `"` because we need one of `"` or `'` and apostrophes (`'`) are likely more commonly used, so disallowing `"`.