### PR TITLE
Bugfixing When a pandas Column is Typed as Non-String

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - `earliest` transformation: finds earliest date among metadata [PR #9](https://github.com/phac-nml/metadatatransformation/pull/9)
 - `populate` transformation: populates an output column with a specific value [PR #10](https://github.com/phac-nml/metadatatransformation/pull/10)
 
+### `Fixed`
+
+- A crash when calculating age if an entire date column contained only floats.
+
 ## [1.0.0] - 2025/03/07
 
 Initial release of phac-nml/metadatatransformation.

--- a/bin/transform.py
+++ b/bin/transform.py
@@ -131,12 +131,12 @@ def calculate_age(row):
     date_1_string = row.iloc[DATE_1_INDEX]
     date_2_string = row.iloc[DATE_2_INDEX]
 
-    # Are the dates in the correct format?
+    # Are the dates in the correct type (string) and format?
     try:
         date_1 = datetime.strptime(date_1_string, DATE_FORMAT)
         date_2 = datetime.strptime(date_2_string, DATE_FORMAT)
 
-    except ValueError:
+    except (TypeError, ValueError) as error:
         age = numpy.nan
         age_valid = False
         age_error = "The date format does not match the expected format (YYYY-MM-DD)."

--- a/tests/data/samplesheets/age/float_columns.csv
+++ b/tests/data/samplesheets/age/float_columns.csv
@@ -1,0 +1,4 @@
+sample,sample_name,metadata_1,metadata_2,metadata_3,metadata_4,metadata_5,metadata_6,metadata_7,metadata_8
+sample1,"ABC",1.1,1.2,1.3,1.4,1.5,1.6,1.7,1.8
+sample2,"DEF",2.1,2.2,2.3,2.4,2.5,2.6,2.7,2.8
+sample3,"GHI",3.1,3.2,3.3,3.4,3.5,3.6,3.7,3.8

--- a/tests/pipelines/age.nf.test
+++ b/tests/pipelines/age.nf.test
@@ -404,4 +404,62 @@ nextflow_pipeline {
             assert iridanext_metadata.sample9."age at collection" == "49"
         }
     }
+
+    test("Float columns") {
+        tag "pipeline_age"
+        tag "pipeline_age_float_columns"
+
+        when {
+            params {
+                input = "$baseDir/tests/data/samplesheets/age/float_columns.csv"
+                outdir = "results"
+
+                transformation = "age"
+                metadata_1_header "date_of_birth"
+                metadata_2_header "collection_date"
+                age_header "age_at_collection"
+            }
+        }
+
+        then {
+            assert workflow.success
+            assert path("$launchDir/results").exists()
+
+            // Check Transformation (Machine-Readable)
+            def transformation = path("$launchDir/results/transformation/transformation.csv")
+            assert transformation.exists()
+
+            assert transformation.text.contains("sample")
+            assert transformation.text.contains("sample1")
+            assert transformation.text.contains("sample2")
+            assert transformation.text.contains("sample3")
+
+            // Check Results (Human-Readable)
+            def results = path("$launchDir/results/transformation/results.csv")
+            assert results.exists()
+
+            assert results.text.contains("sample,sample_name,date_of_birth,collection_date,age_at_collection,age_at_collection_valid,age_at_collection_error")
+            assert results.text.contains("sample1,ABC,1.1000,1.2000,,False,The date format does not match the expected format (YYYY-MM-DD).")
+            assert results.text.contains("sample2,DEF,2,2,,False,The date format does not match the expected format (YYYY-MM-DD).")
+            assert results.text.contains("sample3,GHI,3,3,,False,The date format does not match the expected format (YYYY-MM-DD).")
+
+            // Check IRIDA Next JSON Output
+            def iridanext_json = path("$launchDir/results/iridanext.output.json").json
+            def iridanext_global = iridanext_json.files.global
+            def iridanext_metadata = iridanext_json.metadata.samples
+
+            assert iridanext_global.findAll { it.path == "transformation/results.csv" }.size() == 1
+
+            assert iridanext_metadata.size() == 3
+
+            assert iridanext_metadata.containsKey("sample1")
+            assert iridanext_metadata.sample1.containsKey("age_at_collection") == false
+
+            assert iridanext_metadata.containsKey("sample2")
+            assert iridanext_metadata.sample2.containsKey("age_at_collection") == false
+
+            assert iridanext_metadata.containsKey("sample3")
+            assert iridanext_metadata.sample3.containsKey("age_at_collection") == false
+        }
+    }
 }


### PR DESCRIPTION
When the sample sheet looks like this:

```
sample,sample_name,metadata_1,metadata_2
sample1,ABC,1.1,1.2
sample2,DEF,2.1,2.2
sample3,GHI,3.1,3.2
```

Then pandas will automatically cast `metadata_1` and `metadata_2` as float columns (i.e. not string columns). This causes a `TypeError`, not `ValueError` when trying to parse these as dates. It was causing a whole-pipeline crash, rather than catching the error.